### PR TITLE
Update MAX7219.cs

### DIFF
--- a/Glovebox.Graphics/Drivers/MAX7219.cs
+++ b/Glovebox.Graphics/Drivers/MAX7219.cs
@@ -137,6 +137,8 @@ namespace Glovebox.Graphics.Drivers
         {
             byte row;
 
+            if (input.Length>1 && rotate==0)
+                Array.Reverse(input);
 
             // perform any required display rotations
             for (int rotations = 0; rotations < (int)rotate; rotations++)


### PR DESCRIPTION
When Multiple displays are used and no rotation is used the panel array needs to be reversed.
